### PR TITLE
fix: defer lookup maps build

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -85,7 +85,14 @@ func (c *compiler) AddPass(stage CompilerPassStage, priority int, pass CompilerP
 }
 
 func (c *compiler) Compile(builder *ContainerBuilder) error {
-	return c.config.ForEach(func(pass CompilerPass) error {
+	err := c.config.ForEach(func(pass CompilerPass) error {
 		return pass.Compile(builder)
 	})
+	if err != nil {
+		return err
+	}
+
+	builder.container.finalise()
+
+	return nil
 }

--- a/container.go
+++ b/container.go
@@ -21,7 +21,7 @@ type container struct {
 	instances map[ID]any
 
 	// Lookup maps:
-	private map[ID]struct{}
+	private map[ID]nothing
 	byTag   map[TagID][]ID
 }
 
@@ -32,7 +32,7 @@ func newContainer() *container {
 
 		instances: make(map[ID]any),
 
-		private: make(map[ID]struct{}),
+		private: make(map[ID]nothing),
 		byTag:   make(map[TagID][]ID),
 	}
 }
@@ -142,4 +142,16 @@ func (c *container) getByTag(tag TagID, filterPrivate bool) ([]any, error) {
 func (c *container) isPrivate(id ID) bool {
 	_, ok := c.private[c.resolveAlias(id)]
 	return ok
+}
+
+func (c *container) finalise() {
+	for _, def := range c.definitions {
+		if !def.public {
+			c.private[def.id] = nothing{}
+		}
+
+		for _, tag := range def.GetTags() {
+			c.byTag[tag.ID()] = append(c.byTag[tag.ID()], def.id)
+		}
+	}
 }

--- a/container_builder.go
+++ b/container_builder.go
@@ -43,13 +43,6 @@ func (b *ContainerBuilder) SetDefinitions(definitions ...*Definition) *Container
 func (b *ContainerBuilder) AddDefinitions(definitions ...*Definition) *ContainerBuilder {
 	for _, def := range definitions {
 		b.container.definitions[def.id] = def
-
-		if !def.public {
-			b.container.private[def.id] = struct{}{}
-		}
-		for _, tag := range def.GetTags() {
-			b.container.byTag[tag.ID()] = append(b.container.byTag[tag.ID()], def.id)
-		}
 	}
 	return b
 }

--- a/util.go
+++ b/util.go
@@ -7,6 +7,8 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
+type nothing = struct{}
+
 // FQN returns the fully qualified name of the type parameter.
 func FQN[T any]() ID {
 	return fqn(typeOf[T]())


### PR DESCRIPTION
With this change, it's now possible to modify existing definition's visibility and tags. Previously, those changes weren't reflected in the lookup maps.