### PR TITLE
fix: move finalization to compiler pass

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -12,6 +12,8 @@ const (
 	PreValidation
 	Validation
 	PostValidation
+	Finalization
+	PostFinalization
 	compilerPassStageNumber
 )
 
@@ -41,7 +43,13 @@ func newCompilerPassConfig() compilerPassConfig {
 				NewCycleValidationPass(),
 			},
 		},
-		PostValidation: {
+		PostValidation: {},
+		Finalization: {
+			0: {
+				NewFinalizationPass(),
+			},
+		},
+		PostFinalization: {
 			0: {
 				NewEagerInitPass(),
 			},
@@ -93,8 +101,6 @@ func (c *compiler) Compile(builder *ContainerBuilder) error {
 	if err != nil {
 		return err
 	}
-
-	builder.container.finalise()
 
 	return nil
 }

--- a/compiler_pass.go
+++ b/compiler_pass.go
@@ -245,7 +245,24 @@ func NewCycleValidationPass() CompilerPassFunc {
 	}
 }
 
-// Stage: PostValidation
+// Stage: Finalization
+
+func NewFinalizationPass() CompilerPassFunc {
+	return func(builder *ContainerBuilder) error {
+		for _, def := range builder.GetDefinitions() {
+			if !def.public {
+				builder.container.private[def.id] = nothing{}
+			}
+
+			for _, tag := range def.GetTags() {
+				builder.container.byTag[tag.ID()] = append(builder.container.byTag[tag.ID()], def.id)
+			}
+		}
+		return nil
+	}
+}
+
+// Stage: PostFinalization
 
 // NewEagerInitPass returns a compiler pass that initializes all services that are marked as eager.
 func NewEagerInitPass() CompilerPassFunc {

--- a/container.go
+++ b/container.go
@@ -143,15 +143,3 @@ func (c *container) isPrivate(id ID) bool {
 	_, ok := c.private[c.resolveAlias(id)]
 	return ok
 }
-
-func (c *container) finalise() {
-	for _, def := range c.definitions {
-		if !def.public {
-			c.private[def.id] = nothing{}
-		}
-
-		for _, tag := range def.GetTags() {
-			c.byTag[tag.ID()] = append(c.byTag[tag.ID()], def.id)
-		}
-	}
-}


### PR DESCRIPTION
This change fixes an issue where tagged arguments are not resolved for eager services. The issue resulted from the eager init pass being executed before building the tags lookup map. Now, the eager init pass happens after the finalization pass.