### PR TITLE
fix(scopes): child scope name is the parent id, not type name

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -200,7 +200,7 @@ func (b *ServiceDefinitionBuilder) Build(scope *di.Scope) (joinedErrs error) {
 	}
 
 	if len(b.children) > 0 {
-		childScope := scope.NewChild(b.def.String())
+		childScope := scope.NewChild(b.def.ID().String())
 
 		for _, child := range b.children {
 			err := child.Build(childScope)


### PR DESCRIPTION
The original behaviour caused conflicts when 2 services of the same type defined child scopes. Using service ID, which is unique, solves the issue.