### PR TITLE
fix(scopes): function child scope name is the parent id, not type name

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,11 @@ There are 3 settings that can be configured globally, or per-service/function.
 >
 > Changing the defaults will not affect the already-existing definitions!
 
+> ⚠️ The global defaults are **not safe for concurrent use**.
+> They are package-level variables with no synchronization.
+> Only change them once at program startup (e.g. in `init()` or at the top of `main`),
+> before any `di.Svc`/`di.Func` calls and before spawning goroutines that use the package.
+
 #### Lazy/Eager
 
 By default, the container is lazy - it will only instantiate a service or execute a function when you request it.
@@ -501,6 +506,9 @@ Just like factories and functions, the dependencies (arguments) of the method ar
 > if service A depends on service B, and service B depends on service A,
 > godi won't allow you to inject A to B and B to A via factories, as this would lead to an infinite loop.
 > Instead, you can inject A to B via a factory, and B to A via a method call.
+
+> ⚠️ Registering the same method twice on one service silently **replaces** the first registration.
+> Only the last `MethodCall` for a given method name takes effect.
 
 #### Example
 

--- a/definition.go
+++ b/definition.go
@@ -292,7 +292,13 @@ func (b *FunctionDefinitionBuilder) Build(scope *di.Scope) (joinedErrs error) {
 	}
 
 	if len(b.children) > 0 {
-		childScope := scope.NewChild(b.def.String())
+		for _, child := range b.children {
+			if err := child.ParseFactory(); err != nil {
+				joinedErrs = errors.Join(joinedErrs, errorsx.Wrap(err, "invalid child"))
+			}
+		}
+
+		childScope := scope.NewChild(b.def.ID().String())
 
 		for _, child := range b.children {
 			err := child.Build(childScope)

--- a/di.go
+++ b/di.go
@@ -5,25 +5,24 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/michalkurzeja/godi/v2/di"
 	"github.com/michalkurzeja/godi/v2/internal/util"
 )
 
 type Container interface {
-	HasService(id di.ID) bool
-	GetService(id di.ID) (any, error)
-	GetServices(ids ...di.ID) (svcs []any, err error)
+	HasService(id ID) bool
+	GetService(id ID) (any, error)
+	GetServices(ids ...ID) (svcs []any, err error)
 	GetServicesIDsByType(typ reflect.Type) []ID
 	GetServicesByType(typ reflect.Type) ([]any, error)
 	GetServicesIDsByLabel(label Label) []ID
-	GetServicesByLabel(label di.Label) ([]any, error)
-	HasFunction(id di.ID) bool
-	ExecuteFunction(id di.ID) ([]any, error)
-	ExecuteFunctions(ids ...di.ID) (results [][]any, err error)
+	GetServicesByLabel(label Label) ([]any, error)
+	HasFunction(id ID) bool
+	ExecuteFunction(id ID) ([]any, error)
+	ExecuteFunctions(ids ...ID) (results [][]any, err error)
 	GetFunctionsIDsByType(typ reflect.Type) []ID
 	ExecuteFunctionsByType(typ reflect.Type) ([][]any, error)
 	GetFunctionsIDsByLabel(label Label) []ID
-	ExecuteFunctionsByLabel(label di.Label) ([][]any, error)
+	ExecuteFunctionsByLabel(label Label) ([][]any, error)
 	Print(w io.Writer)
 }
 

--- a/di/compiler_ops.go
+++ b/di/compiler_ops.go
@@ -126,7 +126,7 @@ func (p *autowiringPass) Run(builder *ContainerBuilder) error {
 		for _, method := range def.MethodCalls() {
 			err := p.autowire(method.Args())
 			if err != nil {
-				return errorsx.Wrapf(err, "failed to autowire smethod %s", method)
+				return errorsx.Wrapf(err, "failed to autowire method %s", method)
 			}
 		}
 	}
@@ -191,8 +191,8 @@ func (p *argValidationPass) Run(builder *ContainerBuilder) error {
 		}
 	}
 
-	for scope, def := range builder.FunctionDefinitionsSeq() {
-		err := p.validateArgs(scope, def.Func().Args())
+	for _, def := range builder.FunctionDefinitionsSeq() {
+		err := p.validateArgs(def.EffectiveScope(), def.Func().Args())
 		if err != nil {
 			joinedErr = errors.Join(joinedErr, errorsx.Wrapf(err, "invalid function %s", def))
 		}

--- a/di_test.go
+++ b/di_test.go
@@ -859,6 +859,21 @@ func TestGodi(t *testing.T) {
 			},
 		},
 		{
+			name: "function child service can be used as an autowired dependency",
+			build: func(b *di.Builder, refs *Refs) {
+				b.Functions(
+					di.Func(NewTestSvcStrArg).
+						Children(di.SvcVal("foo")),
+				)
+			},
+			assert: func(t *testing.T, c di.Container, refs *Refs) {
+				got, err := di.ExecByType[func(string) *TestSvc](c)
+				require.NoError(t, err)
+				require.Len(t, got, 1)
+				require.Equal(t, []any{"foo"}, got[0].(*TestSvc).Args)
+			},
+		},
+		{
 			name: "returns an error when executing a function that doesn't exist",
 			assert: func(t *testing.T, c di.Container, refs *Refs) {
 				_, err := di.ExecByType[func() *TestSvc](c)

--- a/extras/override_arg.go
+++ b/extras/override_arg.go
@@ -23,7 +23,7 @@ func OverrideSvcArg(ref godi.SvcReference, slotIdx uint, arg any) *di.CompilerPa
 		}
 		a, err := godi.Arg(arg).Build()
 		if err != nil {
-			return errorsx.Wrap(err, "cannot override argument of %s: invalid arg")
+			return errorsx.Wrapf(err, "cannot override argument of %s: invalid arg", ref)
 		}
 		err = def.Factory().Args().SetSlot(di.NewSlottedArg(a, slotIdx))
 		if err != nil {
@@ -47,7 +47,7 @@ func OverrideFuncArg(ref godi.FuncReference, slotIdx uint, arg any) *di.Compiler
 		}
 		a, err := godi.Arg(arg).Build()
 		if err != nil {
-			return errorsx.Wrap(err, "cannot override argument of %s: invalid arg")
+			return errorsx.Wrapf(err, "cannot override argument of %s: invalid arg", ref)
 		}
 		err = def.Func().Args().SetSlot(di.NewSlottedArg(a, slotIdx))
 		if err != nil {


### PR DESCRIPTION
The original behaviour caused conflicts when 2 services of the same type defined child scopes. Using service ID, which is unique, solves the issue. Also included are:
- fix to resolution of function child scopes during arg validation
- some typos in error messages
- minor README updates with some caveats warnings