### PR TITLE
fix(compiler): credit a failing pass with the wiring it did

### DIFF
--- a/di/compiler.go
+++ b/di/compiler.go
@@ -248,6 +248,10 @@ func (c *Compiler) Run(builder *ContainerBuilder) error {
 		}
 		builder.container.creditDiagnosticsTo(reported, pass.name)
 
+		// Before the check below: the pass ran and did the work, and that it also
+		// objected to something does not make its edits the user's.
+		c.creditPendingWiring(builder.container, pass.argOrigin, pass.bindOrigin, pass.name)
+
 		if err := builder.container.diagnosticErrors(reported); err != nil {
 			// Kept: the builder still stands, and its graph shows how far the
 			// container got.
@@ -258,7 +262,6 @@ func (c *Compiler) Run(builder *ContainerBuilder) error {
 		// Asked of the pass, not of its name. Nothing stops a user calling their
 		// own pass "autowiring".
 		c.autowired = c.autowired || pass.argOrigin == ArgOriginAutowiring
-		c.creditPendingWiring(builder.container, pass.argOrigin, pass.bindOrigin, pass.name)
 
 		err = c.schedulePending(pass, i+1)
 		if err != nil {
@@ -332,8 +335,9 @@ func (c *Compiler) Progress() CompilerProgress {
 // creditPendingWiring names whoever changed the wiring since the last call, and
 // only that wiring. Each pass is credited with its own work.
 //
-// It runs before the first pass and again after each one. That is what tells an
-// argument the user wired from one a pass wired.
+// It runs before the first pass and again after each one, whether or not the pass
+// objected to something. That is what tells an argument the user wired from one a
+// pass wired.
 func (c *Compiler) creditPendingWiring(container *Container, args ArgOrigin, binds BindOrigin, pass string) {
 	for slot := range container.slotsSeq() {
 		if slot.dirty {

--- a/di/compiler_internal_test.go
+++ b/di/compiler_internal_test.go
@@ -1,6 +1,7 @@
 package di
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -133,4 +134,40 @@ func TestSlotOriginCreditsThirdPartyPassByName(t *testing.T) {
 	// The autowired slot is untouched by the override pass.
 	require.Equal(t, ArgOriginAutowiring, slots[0].origin)
 	require.Equal(t, "autowiring", slots[0].originPass)
+}
+
+// A pass that objects to one argument still wired everything else it handles, and
+// the graph of a build that stopped is where that difference matters most. Leaving
+// its work unattributed reads as wiring the user did.
+func TestAFailingPassIsStillCreditedWithWhatItWired(t *testing.T) {
+	t.Parallel()
+
+	factory, err := NewFactory(newTestConsumer, NewLiteralArg("hello"))
+	require.NoError(t, err)
+	impl, err := NewFactory(newTestImpl)
+	require.NoError(t, err)
+
+	// Replaces the literal, then objects to the argument beside it.
+	failing := NewCompilerPass("my override", PreValidation, CompilerOpFunc(func(b *ContainerBuilder) error {
+		if err := factory.Args().SetSlot(NewSlottedArg(NewLiteralArg("overridden"), 1)); err != nil {
+			return err
+		}
+		for _, def := range b.ServiceDefinitionsSeq() {
+			if def.Type() == reflect.TypeFor[*testConsumer]() {
+				b.ReportError(AtServiceArg(def, def.Factory().Args().Slots()[0]), errors.New("not good enough"), "")
+			}
+		}
+		return nil
+	}))
+
+	builder, err := buildAttributed(t, []*CompilerPass{failing}, NewServiceDefinition(factory), NewServiceDefinition(impl))
+	require.ErrorContains(t, err, "not good enough")
+
+	slots := factory.Args().Slots()
+	require.Equal(t, ArgOriginCompilerPass, slots[1].origin)
+	require.Equal(t, "my override", slots[1].originPass)
+
+	progress := builder.Compiler().Progress()
+	require.Equal(t, "my override", progress.Failed)
+	require.NotContains(t, progress.Done, "my override", "a pass that stopped the build has not finished")
 }

--- a/docs/v2/documentation.md
+++ b/docs/v2/documentation.md
@@ -452,6 +452,9 @@ Reading it is open — an override pass that replaces only what autowiring chose
 Declaring it is not: what a pass's edits mean is godi's own, so a pass is credited with its work
 rather than claiming godi's.
 
+A pass is credited with what it wired even when it also reported an error. The graph of a build that
+stopped is where the difference matters most, and the wiring the failing pass did is still its own.
+
 **Never identify a pass by name.** Names are neither unique nor stable, and a third-party pass may
 be called "autowiring".
 

--- a/graph_test.go
+++ b/graph_test.go
@@ -124,6 +124,18 @@ func paramOf(t *testing.T, g *graph.Graph, nodeType string, index int) *graph.Pa
 	return nil
 }
 
+func bindingOf(t *testing.T, g *graph.Graph, iface string) *graph.Binding {
+	t.Helper()
+
+	for _, b := range g.Bindings {
+		if b.Interface == iface {
+			return b
+		}
+	}
+	t.Fatalf("no binding of %s in graph", iface)
+	return nil
+}
+
 func nodeOf(t *testing.T, g *graph.Graph, typeShort string) *graph.Node {
 	t.Helper()
 

--- a/snapshot_faults_test.go
+++ b/snapshot_faults_test.go
@@ -207,6 +207,30 @@ func TestAFailedBuildShowsWhatTheCompilerObjectedTo(t *testing.T) {
 	}
 }
 
+// A pass is credited with what it wired even when it also objected to something.
+// The failure snapshot is the main reader of a partial graph, and this is where the
+// difference matters most: the interface binding pass could not choose between two
+// implementations, but it had already bound every other interface it handles, and
+// none of that is wiring the user did.
+func TestAFailingPassStillOwnsTheWiringItDid(t *testing.T) {
+	g := graphOfFailedBuild(t, godi.New().Services(
+		// Two Reporters, so the pass objects to the argument that takes one.
+		godi.Svc(NewFileReporter), godi.Svc(NewJSONReporter), godi.Svc(NewAudit),
+		// One Greeter, which the same pass binds before it gives up.
+		godi.Svc(NewEnGreeter), godi.Svc(NewGreeterHolder),
+	))
+
+	require.Equal(t, "interface binding", g.Snapshot.Failed)
+	require.NotContains(t, g.Snapshot.Done, "interface binding")
+	require.False(t, g.Snapshot.Autowired, "the build stopped before autowiring")
+
+	require.Len(t, g.Bindings, 1, "the pass bound the interface it could")
+	binding := bindingOf(t, g, "github.com/michalkurzeja/godi/v2_test.Greeter")
+	require.Equal(t, graph.BindOriginAutobinding, binding.Origin,
+		"a failing pass's own binding must not read as one the user declared")
+	require.Equal(t, "interface binding", binding.OriginPass)
+}
+
 // A definition that will not parse never becomes a node, so there is nothing
 // narrower than the container to say it on. Without this the snapshot leaves the
 // service out and says nothing at all.


### PR DESCRIPTION
Compilation stopped before the pass was credited, so everything it wired kept the construction default and read as manual. The failure snapshot is the main reader of a partial graph, and it blamed whoever wrote the container for bindings the interface binding pass had just created.