### PR TITLE
fix(defaults)!: apply container defaults where a definition is registered

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,23 @@ The cost, measured: a warm resolve is ~14ns slower, a *parallel* warm resolve is
 the old exclusive mutex, and two goroutines building two different services for the first time go
 one after the other. `BenchmarkResolve`/`BenchmarkResolveParallel` exist to keep that honest.
 
+### Defaults are applied at registration
+
+`Scope.AddServiceDefinitions` and `AddFunctionDefinitions` fill in the properties a definition's
+registration did not choose, from the container's `Defaults`. Every route in goes through them — the
+facade builders, `ParseAndBuild`, a pass reaching in via `builder.RootScope()` — so a compiler pass
+needs to know nothing about defaults to get them right. `ContainerBuilder.Defaults()` is for reading
+them, not for applying them.
+
+The definition remembers whether its registration chose each property (`property`,
+`di/definition_base.go`). That bookkeeping used to sit on the facade's `ServiceDefinitionBuilder`,
+which is why `di.New(di.DefaultEager())` did nothing for a definition built inside a pass. Do not
+move it back.
+
+The deprecated process-wide `SetDefault*` globals have one reader left, `NewDefaults`. A definition
+gets its properties from the container it is registered in, never from the process. Do not seed them
+in a constructor.
+
 ### Provenance: who wired what
 
 The whole point of the graph is telling apart an argument you wrote, one godi autowired, and one

--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ c, err := di.New(di.DefaultEager()).
 
 The defaults belong to the container they are given to, so two containers in one process can disagree and a
 library cannot change its host's.
+They are applied when a definition is registered, so a definition a compiler pass registers takes them too.
 
 > ⚠️ The `di.SetDefault*` functions set the same three for every container in the process.
 > They still work and are deprecated: a package-level default means a test that flips one leaks into the next,

--- a/builder.go
+++ b/builder.go
@@ -10,7 +10,7 @@ import (
 // This is the recommended entrypoint to the godi library.
 func New(opts ...BuilderOption) *Builder {
 	conf := newConfig(opts)
-	return &Builder{cb: di.NewContainerBuilder(conf), defaults: conf.Defaults}
+	return &Builder{cb: di.NewContainerBuilder(conf)}
 }
 
 // Builder is a helper for building a container.
@@ -24,10 +24,6 @@ type Builder struct {
 	functions []*FunctionDefinitionBuilder
 	bindings  []*InterfaceBindingBuilder
 	passes    []*di.CompilerPass
-
-	// defaults are what a definition takes for the properties its registration
-	// did not set.
-	defaults di.Defaults
 
 	// prepared counts how many of each have been handed to the container builder
 	// already, so that registering more after a prepare still builds the lot.
@@ -104,7 +100,6 @@ func (b *Builder) prepare() error {
 	// fault already reported and not a second one.
 	parsed := make([]*ServiceDefinitionBuilder, 0, len(services))
 	for _, builder := range services {
-		builder.applyDefaults(b.defaults)
 		if err := builder.ParseFactory(); err != nil {
 			b.registrationFailed(err, builder.def.RegisteredAt())
 			continue
@@ -120,7 +115,6 @@ func (b *Builder) prepare() error {
 	}
 
 	for _, builder := range b.functions[b.prepared.functions:] {
-		builder.applyDefaults(b.defaults)
 		if err := builder.Build(b.cb.RootScope()); err != nil {
 			b.registrationFailed(err, builder.def.RegisteredAt())
 			continue

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	di "github.com/michalkurzeja/godi/v2"
+	godi "github.com/michalkurzeja/godi/v2"
+	"github.com/michalkurzeja/godi/v2/di"
 )
 
 type eagerly struct{}
@@ -23,14 +24,14 @@ func TestDefaultsBelongToTheContainerTheyWereGivenTo(t *testing.T) {
 
 	var eager, lazy bool
 
-	_, err := di.New(di.DefaultEager()).
-		Services(di.Svc(newEagerly, &eager)).
+	_, err := godi.New(godi.DefaultEager()).
+		Services(godi.Svc(newEagerly, &eager)).
 		Build()
 	require.NoError(t, err)
 	require.True(t, eager, "the container was told to build everything as it was built")
 
-	_, err = di.New().
-		Services(di.Svc(newEagerly, &lazy)).
+	_, err = godi.New().
+		Services(godi.Svc(newEagerly, &lazy)).
 		Build()
 	require.NoError(t, err)
 	require.False(t, lazy, "and the next container was told nothing of the sort")
@@ -43,8 +44,8 @@ func TestARegistrationOutranksTheDefault(t *testing.T) {
 
 	var built bool
 
-	_, err := di.New(di.DefaultEager()).
-		Services(di.Svc(newEagerly, &built).Lazy()).
+	_, err := godi.New(godi.DefaultEager()).
+		Services(godi.Svc(newEagerly, &built).Lazy()).
 		Build()
 	require.NoError(t, err)
 	require.False(t, built, "this one asked to wait")
@@ -55,10 +56,81 @@ func TestDefaultsReachAChildDefinition(t *testing.T) {
 
 	var parent, child bool
 
-	_, err := di.New(di.DefaultEager()).
-		Services(di.Svc(newEagerly, &parent).Children(di.Svc(newEagerly, &child))).
+	_, err := godi.New(godi.DefaultEager()).
+		Services(godi.Svc(newEagerly, &parent).Children(godi.Svc(newEagerly, &child))).
 		Build()
 	require.NoError(t, err)
 	require.True(t, parent)
 	require.True(t, child, "a child is registered by the same call and takes the same defaults")
+}
+
+// A definition a compiler pass registers takes the container's defaults, the
+// same as one registered up front.
+func TestDefaultsReachADefinitionBuiltByACompilerPass(t *testing.T) {
+	t.Parallel()
+
+	var built bool
+
+	pass := di.NewCompilerPass("install", di.PreAutomation, di.CompilerOpFunc(
+		func(b *di.ContainerBuilder) error {
+			return godi.Svc(newEagerly, &built).ParseAndBuild(b.RootScope())
+		},
+	))
+
+	_, err := godi.New(godi.DefaultEager()).CompilerPasses(pass).Build()
+	require.NoError(t, err)
+	require.True(t, built, "the container was told to build everything as it was built")
+}
+
+func TestARegistrationInACompilerPassOutranksTheDefault(t *testing.T) {
+	t.Parallel()
+
+	var built bool
+
+	pass := di.NewCompilerPass("install", di.PreAutomation, di.CompilerOpFunc(
+		func(b *di.ContainerBuilder) error {
+			return godi.Svc(newEagerly, &built).Lazy().ParseAndBuild(b.RootScope())
+		},
+	))
+
+	_, err := godi.New(godi.DefaultEager()).CompilerPasses(pass).Build()
+	require.NoError(t, err)
+	require.False(t, built, "this one asked to wait")
+}
+
+// DefaultNotAutowired reaches a pass-built definition too, so godi does not fill
+// an argument the registration left for the caller.
+func TestDefaultNotAutowiredReachesADefinitionBuiltByACompilerPass(t *testing.T) {
+	t.Parallel()
+
+	var built bool
+
+	pass := di.NewCompilerPass("install", di.PreAutomation, di.CompilerOpFunc(
+		func(b *di.ContainerBuilder) error {
+			return godi.Svc(newEagerly).ParseAndBuild(b.RootScope())
+		},
+	))
+
+	_, err := godi.New(godi.DefaultNotAutowired()).
+		Services(godi.Svc(func() *bool { return &built })).
+		CompilerPasses(pass).
+		Build()
+	require.ErrorContains(t, err, "argument 0 is not set")
+}
+
+func TestAPassCanReadTheContainersDefaults(t *testing.T) {
+	t.Parallel()
+
+	var defaults di.Defaults
+
+	pass := di.NewCompilerPass("read", di.PreAutomation, di.CompilerOpFunc(
+		func(b *di.ContainerBuilder) error {
+			defaults = b.Defaults()
+			return nil
+		},
+	))
+
+	_, err := godi.New(godi.DefaultEager(), godi.DefaultNotShared()).CompilerPasses(pass).Build()
+	require.NoError(t, err)
+	require.Equal(t, di.Defaults{Lazy: false, Shared: false, Autowired: true}, defaults)
 }

--- a/definition.go
+++ b/definition.go
@@ -70,10 +70,6 @@ type ServiceDefinitionBuilder struct {
 	methods  []*funcBuilder
 	children []*ServiceDefinitionBuilder
 
-	// True where the caller set the property themselves. The container's
-	// defaults fill in the rest.
-	lazyOverridden, sharedOverridden, autowiredOverridden bool
-
 	factoryParsed bool
 }
 
@@ -114,62 +110,37 @@ func (b *ServiceDefinitionBuilder) Labels(labels ...Label) *ServiceDefinitionBui
 
 func (b *ServiceDefinitionBuilder) Lazy() *ServiceDefinitionBuilder {
 	b.def.SetLazy(true)
-	b.lazyOverridden = true
 	return b
 }
 
 func (b *ServiceDefinitionBuilder) Eager() *ServiceDefinitionBuilder {
 	b.def.SetLazy(false)
-	b.lazyOverridden = true
 	return b
 }
 
 func (b *ServiceDefinitionBuilder) Shared() *ServiceDefinitionBuilder {
 	b.def.SetShared(true)
-	b.sharedOverridden = true
 	return b
 }
 
 func (b *ServiceDefinitionBuilder) NotShared() *ServiceDefinitionBuilder {
 	b.def.SetShared(false)
-	b.sharedOverridden = true
 	return b
 }
 
 func (b *ServiceDefinitionBuilder) Autowired() *ServiceDefinitionBuilder {
 	b.def.SetAutowired(true)
-	b.autowiredOverridden = true
 	return b
 }
 
 func (b *ServiceDefinitionBuilder) NotAutowired() *ServiceDefinitionBuilder {
 	b.def.SetAutowired(false)
-	b.autowiredOverridden = true
 	return b
 }
 
 func (b *ServiceDefinitionBuilder) Children(services ...*ServiceDefinitionBuilder) *ServiceDefinitionBuilder {
 	b.children = append(b.children, services...)
 	return b
-}
-
-// applyDefaults fills in the properties the caller did not set themselves.
-//
-// It runs when the definition is registered, not when it is created. That is what
-// lets the defaults belong to a container rather than to the process.
-func (b *ServiceDefinitionBuilder) applyDefaults(defaults di.Defaults) {
-	if !b.lazyOverridden {
-		b.def.SetLazy(defaults.Lazy)
-	}
-	if !b.sharedOverridden {
-		b.def.SetShared(defaults.Shared)
-	}
-	if !b.autowiredOverridden {
-		b.def.SetAutowired(defaults.Autowired)
-	}
-	for _, child := range b.children {
-		child.applyDefaults(defaults)
-	}
 }
 
 func (b *ServiceDefinitionBuilder) ParseAndBuild(scope *di.Scope) error {
@@ -266,10 +237,6 @@ type FunctionDefinitionBuilder struct {
 	def      *di.FunctionDefinition
 	setFunc  func() error
 	children []*ServiceDefinitionBuilder
-
-	// True where the caller set the property themselves. The container's
-	// defaults fill in the rest.
-	lazyOverridden, autowiredOverridden bool
 }
 
 // Func creates a new FunctionDefinitionBuilder.
@@ -304,45 +271,27 @@ func (b *FunctionDefinitionBuilder) Labels(labels ...Label) *FunctionDefinitionB
 
 func (b *FunctionDefinitionBuilder) Lazy() *FunctionDefinitionBuilder {
 	b.def.SetLazy(true)
-	b.lazyOverridden = true
 	return b
 }
 
 func (b *FunctionDefinitionBuilder) Eager() *FunctionDefinitionBuilder {
 	b.def.SetLazy(false)
-	b.lazyOverridden = true
 	return b
 }
 
 func (b *FunctionDefinitionBuilder) Autowired() *FunctionDefinitionBuilder {
 	b.def.SetAutowired(true)
-	b.autowiredOverridden = true
 	return b
 }
 
 func (b *FunctionDefinitionBuilder) NotAutowired() *FunctionDefinitionBuilder {
 	b.def.SetAutowired(false)
-	b.autowiredOverridden = true
 	return b
 }
 
 func (b *FunctionDefinitionBuilder) Children(services ...*ServiceDefinitionBuilder) *FunctionDefinitionBuilder {
 	b.children = append(b.children, services...)
 	return b
-}
-
-// applyDefaults fills in the properties the caller did not set themselves. See
-// ServiceDefinitionBuilder.applyDefaults.
-func (b *FunctionDefinitionBuilder) applyDefaults(defaults di.Defaults) {
-	if !b.lazyOverridden {
-		b.def.SetLazy(defaults.Lazy)
-	}
-	if !b.autowiredOverridden {
-		b.def.SetAutowired(defaults.Autowired)
-	}
-	for _, child := range b.children {
-		child.applyDefaults(defaults)
-	}
 }
 
 func (b *FunctionDefinitionBuilder) Build(scope *di.Scope) (joinedErrs error) {

--- a/di/config.go
+++ b/di/config.go
@@ -22,8 +22,8 @@ type Defaults struct {
 	Autowired bool
 }
 
-// NewDefaults returns godi's defaults, as the process-wide SetDefault functions
-// leave them.
+// NewDefaults returns what a container starts with: lazy, shared and autowired.
+// The deprecated SetDefault functions move them.
 func NewDefaults() Defaults {
 	return Defaults{Lazy: defaultLazy, Shared: defaultShared, Autowired: defaultAutowired}
 }

--- a/di/container.go
+++ b/di/container.go
@@ -20,6 +20,8 @@ type Container struct {
 	root   *Scope
 	scopes *orderedmap.OrderedMap[string, *Scope]
 
+	defaults Defaults
+
 	// diagnostics is what the compiler passes had to say about this container.
 	// They live here rather than on the builder so that they outlast a build,
 	// whether it succeeded or not.
@@ -38,10 +40,17 @@ type Container struct {
 	mu sync.RWMutex
 }
 
-func NewContainer() *Container {
-	c := &Container{scopes: orderedmap.NewOrderedMap[string, *Scope]()}
+func NewContainer(defaults Defaults) *Container {
+	c := &Container{
+		scopes:   orderedmap.NewOrderedMap[string, *Scope](),
+		defaults: defaults,
+	}
 	c.root = NewScope(RootScope, c, nil)
 	return c
+}
+
+func (c *Container) Defaults() Defaults {
+	return c.defaults
 }
 
 // Diagnostics is what the compiler passes had to say about this container, in

--- a/di/container_builder.go
+++ b/di/container_builder.go
@@ -21,7 +21,7 @@ type ContainerBuilder struct {
 
 func NewContainerBuilder(conf Config) *ContainerBuilder {
 	return &ContainerBuilder{
-		container: NewContainer(),
+		container: NewContainer(conf.Defaults),
 		compiler:  NewCompiler(conf.CompilerConfig),
 	}
 }
@@ -95,6 +95,10 @@ func (b *ContainerBuilder) Container() *Container {
 
 func (b *ContainerBuilder) Compiler() *Compiler {
 	return b.compiler
+}
+
+func (b *ContainerBuilder) Defaults() Defaults {
+	return b.container.Defaults()
 }
 
 func (b *ContainerBuilder) Build() (*Container, error) {

--- a/di/definition.go
+++ b/di/definition.go
@@ -12,8 +12,7 @@ import (
 	"github.com/michalkurzeja/godi/v2/internal/util"
 )
 
-// Defaults for Definition properties, for a definition built without a Config
-// to take them from. These are what NewDefaults returns.
+// The values NewDefaults returns. Nothing else reads them.
 var (
 	defaultLazy      = true
 	defaultShared    = true
@@ -72,14 +71,13 @@ type ServiceDefinition struct {
 	val     reflect.Value
 	fromVal bool
 
-	shared bool
+	shared property
 }
 
 func NewServiceDefinition(factory *Factory) *ServiceDefinition {
 	d := &ServiceDefinition{
 		factory:     factory,
 		methodCalls: make(map[string]*Method),
-		shared:      defaultShared,
 	}
 	d.init(d, captureSource())
 	return d
@@ -124,12 +122,17 @@ func (d *ServiceDefinition) RemoveMethodCalls(names ...string) *ServiceDefinitio
 }
 
 func (d *ServiceDefinition) IsShared() bool {
-	return d.shared
+	return d.shared.val
 }
 
 func (d *ServiceDefinition) SetShared(shared bool) *ServiceDefinition {
-	d.shared = shared
+	d.shared.set(shared)
 	return d
+}
+
+func (d *ServiceDefinition) applyDefaults(defaults Defaults) {
+	d.definition.applyDefaults(defaults)
+	d.shared.fillDefault(defaults.Shared)
 }
 
 // SetVal records that this definition serves a value it was handed, rather than

--- a/di/definition_base.go
+++ b/di/definition_base.go
@@ -22,8 +22,25 @@ type definition[T any] struct {
 	childScope *Scope
 
 	// Properties
-	lazy      bool
-	autowired bool
+	lazy      property
+	autowired property
+}
+
+// property is a definition's lazy, shared or autowired setting. One the
+// registration did not choose takes the container's default at registration.
+type property struct {
+	val    bool
+	chosen bool
+}
+
+func (p *property) set(val bool) {
+	p.val, p.chosen = val, true
+}
+
+func (p *property) fillDefault(val bool) {
+	if !p.chosen {
+		p.val = val
+	}
 }
 
 // init fills in what every definition starts with. The constructor captures the
@@ -33,8 +50,6 @@ func (d *definition[T]) init(self T, src source) {
 	d.self = self
 	d.id = NewID()
 	d.source = src
-	d.lazy = defaultLazy
-	d.autowired = defaultAutowired
 }
 
 func (d *definition[T]) ID() ID {
@@ -100,21 +115,26 @@ func (d *definition[T]) RemoveLabels(labels ...Label) T {
 }
 
 func (d *definition[T]) IsLazy() bool {
-	return d.lazy
+	return d.lazy.val
 }
 
 func (d *definition[T]) SetLazy(lazy bool) T {
-	d.lazy = lazy
+	d.lazy.set(lazy)
 	return d.self
 }
 
 func (d *definition[T]) IsAutowired() bool {
-	return d.autowired
+	return d.autowired.val
 }
 
 func (d *definition[T]) SetAutowired(autowired bool) T {
-	d.autowired = autowired
+	d.autowired.set(autowired)
 	return d.self
+}
+
+func (d *definition[T]) applyDefaults(defaults Defaults) {
+	d.lazy.fillDefault(defaults.Lazy)
+	d.autowired.fillDefault(defaults.Autowired)
 }
 
 // RegisteredAt is where this definition was declared: the first frame outside

--- a/di/scope.go
+++ b/di/scope.go
@@ -427,7 +427,7 @@ func (s *Scope) instantiate(ic *instantiationContext, def *ServiceDefinition) (a
 		return nil, errorsx.Wrapf(err, "failed to execute factory for service %s", def)
 	}
 
-	if def.shared {
+	if def.IsShared() {
 		ic.stage(s, def, svc)
 	}
 	ic.enqueueMethodCalls(def, svc, def.EffectiveScope())
@@ -520,7 +520,12 @@ func (s *Scope) GetServiceDefinitionInChain(id ID) (*ServiceDefinition, bool) {
 	return nil, false
 }
 
+// AddServiceDefinitions registers the definitions in this scope. Each takes the
+// container's defaults for the properties it did not set itself.
 func (s *Scope) AddServiceDefinitions(definitions ...*ServiceDefinition) *Scope {
+	for _, def := range definitions {
+		def.applyDefaults(s.container.defaults)
+	}
 	s.svcs.Add(definitions...)
 	return s
 }
@@ -596,7 +601,12 @@ func (s *Scope) GetFunctionDefinitionInChain(id ID) (*FunctionDefinition, bool) 
 	return nil, false
 }
 
+// AddFunctionDefinitions registers the functions in this scope. See
+// AddServiceDefinitions.
 func (s *Scope) AddFunctionDefinitions(functions ...*FunctionDefinition) *Scope {
+	for _, def := range functions {
+		def.applyDefaults(s.container.defaults)
+	}
 	s.funs.Add(functions...)
 	return s
 }

--- a/di/scope_test.go
+++ b/di/scope_test.go
@@ -83,7 +83,7 @@ func TestAChildScopeCanExecuteAFunctionOfItsParent(t *testing.T) {
 	fn, err := di.NewFunc(reflect.ValueOf(func() { called = true }))
 	require.NoError(t, err)
 
-	c := di.NewContainer()
+	c := di.NewContainer(di.NewDefaults())
 	root := c.Root()
 	def := di.NewFunctionDefinition(fn).SetScope(root)
 	root.AddFunctionDefinitions(def)
@@ -99,7 +99,7 @@ func TestAChildScopeCanExecuteAFunctionOfItsParent(t *testing.T) {
 func TestExecutingAFunctionNoScopeInTheChainHasFails(t *testing.T) {
 	t.Parallel()
 
-	c := di.NewContainer()
+	c := di.NewContainer(di.NewDefaults())
 	child := c.Root().NewChild("child")
 
 	_, err := child.ExecuteFunctionInChain(di.NewID())

--- a/docs/v2/documentation.md
+++ b/docs/v2/documentation.md
@@ -219,7 +219,7 @@ Three settings, each per definition or per container:
 | Autowired / not | autowired | `.Autowired()` / `.NotAutowired()` | `DefaultAutowired()` / `DefaultNotAutowired()` |
 
 What a definition asks for wins; the container's default fills in the rest, as the definition is
-registered.
+registered. A definition a compiler pass registers takes the default the same way.
 
 `SetDefaultLazy`, `SetDefaultEager`, `SetDefaultShared`, `SetDefaultNotShared`,
 `SetDefaultAutowired` and `SetDefaultNotAutowired` set the same three for **every container in the
@@ -257,7 +257,11 @@ c, err := b.Build()
 ```
 
 `ContainerBuilder`: `RootScope()`, `Scope(name)`, `Scopes()`, `ServiceDefinitionsSeq()`,
-`FunctionDefinitionsSeq()`, `Container()`, `Compiler()`, `Build()`.
+`FunctionDefinitionsSeq()`, `Container()`, `Compiler()`, `Defaults()`, `Build()`.
+
+`AddServiceDefinitions` and `AddFunctionDefinitions` are where the container's defaults land. A
+definition takes them for the properties it did not set itself, whether a pass registered it or the
+facade did. `Defaults()` reads them. It does not apply them.
 
 `Container()` is the container being built, and nil once `Build` has handed it over. A failed
 `Build` keeps it.

--- a/plugins/godi/.claude-plugin/plugin.json
+++ b/plugins/godi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "godi",
   "description": "Teaches Claude to correctly write and understand Go code that uses the godi v2 dependency-injection container (github.com/michalkurzeja/godi/v2).",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Michał Kurzeja",
     "email": "mike.kurzeja@gmail.com"

--- a/plugins/godi/skills/godi-v2/SKILL.md
+++ b/plugins/godi/skills/godi-v2/SKILL.md
@@ -293,7 +293,8 @@ Three settings, configurable per definition or per container:
   left out and is then called with none. `Autowired()`/`NotAutowired()`;
   `di.DefaultAutowired()`/`di.DefaultNotAutowired()`.
 
-What a definition asks for wins; the container's default fills in the rest.
+What a definition asks for wins; the container's default fills in the rest, as the definition
+is registered. That includes a definition a compiler pass registers.
 
 ⚠️ The `di.SetDefault*` functions set the same three for **every container in the process**.
 They still work and are deprecated — a test that flips one leaks into the next, and they are
@@ -337,6 +338,9 @@ pass := di.NewCompilerPass("my pass", di.PreAutomation, di.CompilerOpFunc(
     },
 ))
 ```
+
+A definition a pass registers with `svcBuilder.ParseAndBuild(b.RootScope())` takes the
+container's defaults for the properties it did not set itself. `b.Defaults()` reads them.
 
 ## Seeing how a container is wired
 


### PR DESCRIPTION
di.New(di.DefaultEager()) and its siblings had no effect on a definition a compiler pass built. NewContainerBuilder dropped conf.Defaults, and the only code that read them was the facade's prepare(), so a pass-built definition kept whatever the deprecated process-wide globals said. That is why di.SetDefaultEager() worked where the per-container option did not, and why the SetDefault* deprecation could not be finished.

The container now carries its Defaults and Scope.AddServiceDefinitions applies them, so every registration route gets them and a pass author has nothing to remember. Whether a registration chose a property moved off the facade builders onto the definition itself, which is what lets the engine tell an explicit Shared() from silence.

di.NewContainer takes the defaults now, so extension code calling it directly needs updating.

Definition constructors no longer seed from the deprecated globals, leaving NewDefaults their only reader.