### PR TITLE
fix(graph): draw what an ambiguous interface argument could not choose between

### DIFF
--- a/README.md
+++ b/README.md
@@ -1087,6 +1087,20 @@ notices:
   error: main.(*User) argument 0: binding on main.Iface resolves to []main.Iface, which cannot fill an argument of type main.Iface
 ```
 
+Two services implementing one interface stop the build before anything is wired. Nothing fills the
+argument that takes it, so the implementations are drawn as candidates. Both are spelled the same, and
+the fault says where each was registered:
+
+```
+      args:
+        0 <- main.Logger  [none]
+          -> main.(*ConsoleLogger)  [by-type, candidate]
+          -> main.(*ConsoleLogger)  [by-type, candidate]
+          ! error: multiple implementations of interface main.Logger found:
+              main.(*ConsoleLogger) registered at /home/me/app/main.go:41
+              main.(*ConsoleLogger) registered at /home/me/app/main.go:52
+```
+
 A message carries whatever the code that failed put in its error — a factory that could not reach its
 database puts its connection string in yours — and the graph goes into a file and over HTTP. Hold it back
 with `graph.WithDiagnosticMarks()`, `graph.WithoutDiagnostics()` or `graph.WithDiagnosticRedactor(fn)` where

--- a/di/compiler_ops.go
+++ b/di/compiler_ops.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/dominikbraun/graph"
 	"github.com/samber/lo"
@@ -23,7 +24,7 @@ func (p *InterfaceBindingPass) Run(builder *ContainerBuilder) error {
 		for i, slot := range def.Factory().Args().Slots() {
 			err := p.checkAndBind(def.EffectiveScope(), def.ID(), slot)
 			if err != nil {
-				builder.ReportError(AtServiceArg(def, slot), err, "could not bind argument %d of service %s", i, def)
+				p.report(builder, AtServiceArg(def, slot), err, "could not bind argument %d of service %s", i, def)
 			}
 		}
 
@@ -31,7 +32,7 @@ func (p *InterfaceBindingPass) Run(builder *ContainerBuilder) error {
 			for i, slot := range method.Args().Slots() {
 				err := p.checkAndBind(def.EffectiveScope(), def.ID(), slot)
 				if err != nil {
-					builder.ReportError(AtServiceArg(def, slot), err, "could not bind argument %d of method %s", i, method)
+					p.report(builder, AtServiceArg(def, slot), err, "could not bind argument %d of method %s", i, method)
 				}
 			}
 		}
@@ -40,12 +41,27 @@ func (p *InterfaceBindingPass) Run(builder *ContainerBuilder) error {
 		for i, slot := range def.Func().Args().Slots() {
 			err := p.checkAndBind(def.EffectiveScope(), def.ID(), slot)
 			if err != nil {
-				builder.ReportError(AtFunctionArg(def, slot), err, "could not bind argument %d of function %s", i, def)
+				p.report(builder, AtFunctionArg(def, slot), err, "could not bind argument %d of function %s", i, def)
 			}
 		}
 	}
 
 	return nil
+}
+
+// report says what the pass objected to, and names the implementations where it
+// could not choose between them. The graph draws those against the argument, and
+// it is the only account of them there is: the build stops here, so nothing fills
+// the slot and there is no argument to trace.
+func (p *InterfaceBindingPass) report(builder *ContainerBuilder, site Site, err error, wrapFormat string, a ...any) {
+	d := newDiagnosticError(site, err, wrapFormat, a...)
+
+	var ambiguous *ambiguousInterfaceError
+	if errors.As(err, &ambiguous) {
+		d.Related = ambiguous.sites()
+	}
+
+	builder.Report(d)
 }
 
 func (p *InterfaceBindingPass) checkAndBind(scope *Scope, parentID ID, slot *Slot) error {
@@ -80,7 +96,7 @@ func (p *InterfaceBindingPass) checkAndBind(scope *Scope, parentID ID, slot *Slo
 		bindTo, _ = NewCompoundArg(iface, args...) // No error possible - we know that impls implement iface.
 	} else {
 		if len(impls) > 1 {
-			return fmt.Errorf("multiple implementations of interface %s found: %s", util.Signature(iface), impls)
+			return &ambiguousInterfaceError{iface: iface, impls: impls}
 		}
 		bindTo, _ = NewRefArg(impls[0])
 	}
@@ -103,6 +119,39 @@ func (p *InterfaceBindingPass) findImplementations(scope *Scope, parentID ID, if
 		}
 	}
 	return impls
+}
+
+// ambiguousInterfaceError is more than one service implementing the interface an
+// argument asks for, where the argument takes one.
+//
+// It holds the implementations rather than only naming them, so that the pass can
+// report each of them against the argument as well as list them in the message.
+type ambiguousInterfaceError struct {
+	iface reflect.Type
+	impls []*ServiceDefinition
+}
+
+// Error lists the implementations one per line, each with where it was
+// registered. Two services of the same type are spelled the same, and the
+// registration is then all that tells them apart.
+func (e *ambiguousInterfaceError) Error() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "multiple implementations of interface %s found:", util.Signature(e.iface))
+	for _, impl := range e.impls {
+		sb.WriteString("\n  " + impl.String())
+		if at := impl.RegisteredAt(); !at.IsZero() {
+			sb.WriteString(" registered at " + at.String())
+		}
+	}
+	return sb.String()
+}
+
+func (e *ambiguousInterfaceError) sites() []Site {
+	sites := make([]Site, len(e.impls))
+	for i, impl := range e.impls {
+		sites[i] = AtService(impl)
+	}
+	return sites
 }
 
 // AutowiringPass fills in the arguments nobody wrote, by type. It is exported as

--- a/di/diagnostic.go
+++ b/di/diagnostic.go
@@ -100,6 +100,13 @@ type Diagnostic struct {
 	// does not fail the build, and an error-severity diagnostic without one is
 	// reported as its message.
 	Err error
+	// Related is what else this diagnostic is about, where its site names one
+	// place and the fault is about several: the implementations a pass could not
+	// choose between, named against the argument that could not choose. The
+	// dependency graph draws one candidate edge per related definition.
+	//
+	// A related site that names no definition draws nothing.
+	Related []Site
 	// At is where in the source this is about, for a diagnostic whose site cannot
 	// say. A definition that would not parse never became a node with a location
 	// of its own, and the file and line are then all a reader has to go on.

--- a/di_test.go
+++ b/di_test.go
@@ -1135,7 +1135,8 @@ func TestTheContainerWiresWhatItIsGiven(t *testing.T) {
 				)
 			},
 			assertBuildErr: func(t *testing.T, err error) {
-				require.ErrorContains(t, err, `could not bind argument 0 of service github.com/michalkurzeja/godi/v2_test.(*TestSvc): multiple implementations of interface github.com/michalkurzeja/godi/v2_test.TestIface found: [github.com/michalkurzeja/godi/v2_test.(*TestIfaceImpl) github.com/michalkurzeja/godi/v2_test.(*TestIfaceImpl)]`)
+				require.ErrorContains(t, err, `could not bind argument 0 of service github.com/michalkurzeja/godi/v2_test.(*TestSvc): multiple implementations of interface github.com/michalkurzeja/godi/v2_test.TestIface found:`)
+				requireImplsListed(t, err)
 			},
 		},
 		// Interface binding - method calls
@@ -1197,7 +1198,8 @@ func TestTheContainerWiresWhatItIsGiven(t *testing.T) {
 				)
 			},
 			assertBuildErr: func(t *testing.T, err error) {
-				require.ErrorContains(t, err, `could not bind argument 1 of method github.com/michalkurzeja/godi/v2_test.(*TestSvc).AddArgIface: multiple implementations of interface github.com/michalkurzeja/godi/v2_test.TestIface found: [github.com/michalkurzeja/godi/v2_test.(*TestIfaceImpl) github.com/michalkurzeja/godi/v2_test.(*TestIfaceImpl)]`)
+				require.ErrorContains(t, err, `could not bind argument 1 of method github.com/michalkurzeja/godi/v2_test.(*TestSvc).AddArgIface: multiple implementations of interface github.com/michalkurzeja/godi/v2_test.TestIface found:`)
+				requireImplsListed(t, err)
 			},
 		},
 		// Interface binding - functions
@@ -1268,7 +1270,8 @@ func TestTheContainerWiresWhatItIsGiven(t *testing.T) {
 				)
 			},
 			assertBuildErr: func(t *testing.T, err error) {
-				require.ErrorContains(t, err, `could not bind argument 0 of function github.com/michalkurzeja/godi/v2_test.NewTestSvcIfaceArg: multiple implementations of interface github.com/michalkurzeja/godi/v2_test.TestIface found: [github.com/michalkurzeja/godi/v2_test.(*TestIfaceImpl) github.com/michalkurzeja/godi/v2_test.(*TestIfaceImpl)]`)
+				require.ErrorContains(t, err, `could not bind argument 0 of function github.com/michalkurzeja/godi/v2_test.NewTestSvcIfaceArg: multiple implementations of interface github.com/michalkurzeja/godi/v2_test.TestIface found:`)
+				requireImplsListed(t, err)
 			},
 		},
 		// Cycle
@@ -1336,6 +1339,18 @@ func TestTheContainerWiresWhatItIsGiven(t *testing.T) {
 			}
 		})
 	}
+}
+
+// requireImplsListed checks that the ambiguity names each implementation with
+// where it was registered. Both are of the same type and spelled the same, so
+// the registration is the only thing telling the reader which two services the
+// container means. The lines are matched rather than spelled out because they
+// carry this file's own line numbers.
+func requireImplsListed(t *testing.T, err error) {
+	t.Helper()
+
+	impl := `\n  github\.com/michalkurzeja/godi/v2_test\.\(\*TestIfaceImpl\) registered at \S+/di_test\.go:\d+`
+	require.Regexp(t, impl+impl, err.Error())
 }
 
 func TestAnEagerServiceIsBuiltWithTheContainer(t *testing.T) {
@@ -1534,7 +1549,8 @@ func TestTheContainerServesFunctionsAndValuesToo(t *testing.T) {
 				di.Svc(func(a any) string { return fmt.Sprint(a) }),
 			).
 			Build()
-		require.ErrorContains(t, err, "compilation failed: compiler pass (interface binding) returned an error: could not bind argument 0 of service string: multiple implementations of interface interface {} found: [int bool]")
+		require.ErrorContains(t, err, "compilation failed: compiler pass (interface binding) returned an error: could not bind argument 0 of service string: multiple implementations of interface interface {} found:")
+		require.Regexp(t, `\n  int registered at \S+/di_test\.go:\d+\n  bool registered at \S+/di_test\.go:\d+`, err.Error())
 	})
 
 	t.Run("autowire matches a single arg", func(t *testing.T) {

--- a/docs/v2/documentation.md
+++ b/docs/v2/documentation.md
@@ -420,6 +420,21 @@ b.Report(di.Diagnostic{Severity: di.SeverityWarning, Site: di.AtService(def), Me
 | `AtService(def)` / `AtFunction(def)` | The node. |
 | `AtServiceArg(def, slot)` / `AtFunctionArg(def, slot)` | The argument. Factory and method arguments alike. |
 
+A fault about several elements names the rest in `Related`, as sites of their own:
+
+```go
+b.Report(di.Diagnostic{
+	Severity: di.SeverityError,
+	Site:     di.AtServiceArg(def, slot),
+	Message:  "could not choose between the implementations",
+	Related:  []di.Site{di.AtService(one), di.AtService(other)},
+})
+```
+
+The graph draws one candidate edge from the argument to each of them. That is the only account
+of an argument a pass gave up on, since the build stops before anything fills the slot. A related
+site that names no definition draws nothing.
+
 An error-severity diagnostic stops compilation once the reporting pass returns, and `Build` fails
 with its `Err`; a pass that reports one should return `nil` rather than the same error twice. A
 warning or an info note never fails a build, and stays on the container it produced.
@@ -578,6 +593,11 @@ Every format draws an edge feeding an argument that will not resolve, and one th
 cycle, as wrong. How it says so differs, because only one of them has room for both facts: the
 HTML page puts a red glow behind the line, so the line still says who chose the dependency,
 while Graphviz gives an edge one colour and no second layer, so there it turns red outright.
+
+An argument a compiler pass gave up on has no wiring to draw. The build stops there, so the slot
+stays empty. The implementations the pass could not choose between are drawn instead, each as a
+`Candidate` edge, which is what keeps them from reading as dependencies the container chose. An
+ambiguous interface argument is two red edges out of an argument that resolved to neither.
 
 ### 5.6 Formats and the CLI
 

--- a/graph/dot/dot.go
+++ b/graph/dot/dot.go
@@ -419,6 +419,9 @@ func (p *printer) edgeLabel(edge *graph.Edge) string {
 	if edge.Cycle {
 		parts = append(parts, "cycle")
 	}
+	if edge.Candidate {
+		parts = append(parts, "candidate")
+	}
 	return strings.Join(parts, ", ")
 }
 
@@ -433,6 +436,9 @@ func (p *printer) edgeClasses(edge *graph.Edge) string {
 	if edge.Cycle {
 		classes = append(classes, "cycle")
 	}
+	if edge.Candidate {
+		classes = append(classes, "candidate")
+	}
 	return strings.Join(classes, " ")
 }
 
@@ -446,6 +452,9 @@ func (p *printer) edgeTooltip(edge *graph.Edge) string {
 	}
 	sb.WriteString("\nresolved: ")
 	sb.WriteString(string(edge.Resolution))
+	if edge.Candidate {
+		sb.WriteString("\ncandidate: the container could not choose")
+	}
 	for _, hop := range edge.Bindings {
 		sb.WriteString("\nvia binding ")
 		sb.WriteString(render.Short(hop.Interface))

--- a/graph/extract/args.go
+++ b/graph/extract/args.go
@@ -215,13 +215,16 @@ var (
 	errorType    = reflect.TypeFor[error]()
 )
 
-func (x *extractor) edge(p *graph.Param, to graph.NodeID, res graph.Resolution, hops []graph.BindingHop) {
+// edge records one dependency injected into one argument, and returns it so that
+// a caller drawing something other than a resolved dependency can say so. It is
+// nil when there was nothing to point at.
+func (x *extractor) edge(p *graph.Param, to graph.NodeID, res graph.Resolution, hops []graph.BindingHop) *graph.Edge {
 	if to == "" {
 		x.unresolved(p, "dependency is not registered in this container")
-		return
+		return nil
 	}
 
-	x.out.Edges = append(x.out.Edges, &graph.Edge{
+	edge := &graph.Edge{
 		ID:         graph.NewEdgeID(p.ID, p.EdgeCount),
 		From:       p.Node,
 		To:         to,
@@ -233,8 +236,10 @@ func (x *extractor) edge(p *graph.Param, to graph.NodeID, res graph.Resolution, 
 		Bindings:   hops,
 		ParamType:  cmp.Or(p.ElemType, p.Type),
 		Ordinal:    p.EdgeCount,
-	})
+	}
+	x.out.Edges = append(x.out.Edges, edge)
 	p.EdgeCount++
+	return edge
 }
 
 // unresolved records what an argument failed to find. It is extraction's own

--- a/graph/extract/diagnostics.go
+++ b/graph/extract/diagnostics.go
@@ -25,6 +25,34 @@ func (x *extractor) reportedDiagnostics() {
 			Pass:     d.Pass,
 			Location: x.registered(d.At),
 		})
+		x.candidateEdges(d)
+	}
+}
+
+// candidateEdges draws what a pass could not choose between, against the argument
+// that could not choose.
+//
+// It is the second route to an edge, and the only one open to an argument that
+// resolved to nothing: a pass that stops the build leaves every slot after it
+// empty, and an empty slot has no argument to trace. What was on offer is then
+// the pass's own account or nothing.
+//
+// An argument that already produced edges keeps them. A pass naming what the
+// wiring found is saying it again, not adding to it.
+func (x *extractor) candidateEdges(d di.Diagnostic) {
+	p := x.slotParams[d.Site.Slot()]
+	if p == nil || p.EdgeCount > 0 {
+		return
+	}
+
+	for _, related := range d.Related {
+		node := x.siteNode(related)
+		if node == nil {
+			continue
+		}
+		if edge := x.edge(p, node.ID, graph.ResolutionByType, nil); edge != nil {
+			edge.Candidate = true
+		}
 	}
 }
 

--- a/graph/extract/extract_test.go
+++ b/graph/extract/extract_test.go
@@ -196,3 +196,99 @@ func TestAMethodCallLoopIsNotMarkedAsACycle(t *testing.T) {
 		require.False(t, e.Cycle, "edge %s -> %s (%s) must not be marked as a cycle", e.From, e.To, e.Kind)
 	}
 }
+
+// The candidates a pass reported are drawn against the argument that could not
+// choose between them. A related site that names nothing the graph has draws
+// nothing: the container itself is not a node, and an edge to nowhere is worse
+// than no edge.
+func TestCandidatesAreDrawnAgainstTheArgumentThatCouldNotChoose(t *testing.T) {
+	t.Parallel()
+
+	b := di.NewContainerBuilder(di.NewConfig())
+
+	storeFactory, err := di.NewFactory(NewStore)
+	require.NoError(t, err)
+	store := di.NewServiceDefinition(storeFactory).SetScope(b.RootScope())
+
+	// The pass below stops the build before autowiring, so this argument stays
+	// empty and has nothing to trace — the case the interface binding pass leaves
+	// behind when it gives up.
+	serverFactory, err := di.NewFactory(NewServer)
+	require.NoError(t, err)
+	server := di.NewServiceDefinition(serverFactory).SetScope(b.RootScope())
+
+	b.RootScope().AddServiceDefinitions(store, server)
+
+	b.Compiler().AddPass(di.NewCompilerPass("picky", di.PreAutomation, di.CompilerOpFunc(func(cb *di.ContainerBuilder) error {
+		slot := server.Factory().Args().Slots()[0]
+		cb.Report(di.Diagnostic{
+			Severity: di.SeverityError,
+			Site:     di.AtServiceArg(server, slot),
+			Message:  "could not choose",
+			Related:  []di.Site{di.AtService(store), di.AtContainer()},
+		})
+		return nil
+	})))
+
+	_, err = b.Build()
+	require.Error(t, err)
+
+	g, err := extract.FromBuilder(b)
+	require.NoError(t, err)
+
+	require.Len(t, g.Edges, 1, "the container is not a node, so it is worth no edge")
+	edge := g.Edges[0]
+	require.True(t, edge.Candidate)
+	require.Equal(t, nodeOf(t, g, "extract_test.(*Store)").ID, edge.To)
+	require.True(t, g.EdgeFaulty(edge), "what a pass could not choose between is not wiring that works")
+}
+
+// An argument that resolved has said what it depends on. A pass naming those
+// same services is saying it again, and drawing them a second time would double
+// every dependency it mentions.
+func TestCandidatesAreNotDrawnOnAnArgumentThatResolved(t *testing.T) {
+	t.Parallel()
+
+	pass := di.NewCompilerPass("picky", di.PreFinalization, di.CompilerOpFunc(func(cb *di.ContainerBuilder) error {
+		for _, def := range cb.ServiceDefinitionsSeq() {
+			if def.Type() != reflect.TypeFor[*Server]() {
+				continue
+			}
+			slot := def.Factory().Args().Slots()[0]
+			cb.Report(di.Diagnostic{
+				Severity: di.SeverityWarning,
+				Site:     di.AtServiceArg(def, slot),
+				Message:  "worth a second look",
+				Related:  []di.Site{di.AtService(def)},
+			})
+		}
+		return nil
+	}))
+
+	c, err := godi.New().
+		Services(godi.Svc(NewServer), godi.Svc(NewStore)).
+		CompilerPasses(pass).
+		Build()
+	require.NoError(t, err)
+
+	container, ok := c.(*di.Container)
+	require.True(t, ok)
+
+	g, err := extract.From(container)
+	require.NoError(t, err)
+
+	require.Len(t, g.Edges, 1, "the argument had already said what it resolved to")
+	require.False(t, g.Edges[0].Candidate)
+}
+
+func nodeOf(t *testing.T, g *graph.Graph, typeShort string) *graph.Node {
+	t.Helper()
+
+	for _, n := range g.Nodes {
+		if n.TypeShort() == typeShort {
+			return n
+		}
+	}
+	t.Fatalf("no node of type %s in graph", typeShort)
+	return nil
+}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -497,6 +497,10 @@ type Edge struct {
 	Ordinal   int    `json:"ordinal"`   // Position among the param's edges, i.e. in the injected slice.
 	OfMany    bool   `json:"ofMany"`
 	Cycle     bool   `json:"cycle,omitzero"`
+	// Candidate reports that this is not wiring: it is one of the dependencies
+	// that could have satisfied the argument, which is why the argument is
+	// faulty. The container chose none of them.
+	Candidate bool `json:"candidate,omitzero"`
 }
 
 // PassCredit names the compiler pass responsible for this edge, and is empty when

--- a/graph/html/assets/viewer.js
+++ b/graph/html/assets/viewer.js
@@ -332,6 +332,7 @@ function buildElements() {
 				id: e.id, source: e.from, target: e.to,
 				origin: e.origin, decidedBy: e.decidedBy, kind: e.kind,
 				bound: !!e.bindInterface, cycle: !!e.cycle, faulty: !!e.faulty,
+				candidate: !!e.candidate,
 				// A pass is named however it was responsible. It may have wired
 				// the argument, or created the binding the argument resolved
 				// through. The colour says a pass decided, and this says which.
@@ -1344,6 +1345,7 @@ function resolutionText(e) {
 	const bits = [e.resolution];
 	if (e.bindInterface) bits.push('binding on ' + e.bindInterface + ' (' + boundBy(e) + ')');
 	if (e.cycle) bits.push('cycle');
+	if (e.candidate) bits.push('candidate');
 	return bits.join(' · ');
 }
 

--- a/graph/html/payload.go
+++ b/graph/html/payload.go
@@ -170,6 +170,9 @@ type viewEdge struct {
 	Ordinal int    `json:"ordinal"`
 	OfMany  bool   `json:"ofMany,omitzero"`
 	Cycle   bool   `json:"cycle,omitzero"`
+	// Candidate is a dependency the container could have used and did not: one of
+	// several an argument could not choose between. It is not wiring.
+	Candidate bool `json:"candidate,omitzero"`
 	// Faulty is what the red glow behind the line is drawn from: the argument
 	// this feeds will not resolve. The line keeps its own colour, so a broken
 	// edge still says who chose it.
@@ -314,6 +317,7 @@ func newViewEdge(g *graph.Graph, edge *graph.Edge) viewEdge {
 		Ordinal:    edge.Ordinal,
 		OfMany:     edge.OfMany,
 		Cycle:      edge.Cycle,
+		Candidate:  edge.Candidate,
 		Faulty:     g.EdgeFaulty(edge),
 		Pass:       edge.PassCredit(),
 	}

--- a/graph/text/text.go
+++ b/graph/text/text.go
@@ -364,6 +364,9 @@ func (p *printer) resolution(e *graph.Edge) []string {
 	if e.Cycle {
 		out = append(out, "cycle")
 	}
+	if e.Candidate {
+		out = append(out, "candidate")
+	}
 	return out
 }
 

--- a/plugins/godi/.claude-plugin/plugin.json
+++ b/plugins/godi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "godi",
   "description": "Teaches Claude to correctly write and understand Go code that uses the godi v2 dependency-injection container (github.com/michalkurzeja/godi/v2).",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Michał Kurzeja",
     "email": "mike.kurzeja@gmail.com"

--- a/plugins/godi/skills/godi-v2/SKILL.md
+++ b/plugins/godi/skills/godi-v2/SKILL.md
@@ -381,6 +381,11 @@ An edge feeding an argument that will not resolve is drawn as wrong, and so is o
 closes a cycle. The HTML page glows it red behind the line, keeping the line's own colour for
 who chose it; Graphviz has no second layer, so there the edge turns red outright.
 
+An argument a compiler pass gave up on has no wiring to draw, because the build stops before
+anything fills the slot. The implementations it could not choose between are drawn instead,
+each as a `Candidate` edge. An ambiguous interface argument is two red edges out of an argument
+that resolved to neither.
+
 **A diagnostic is stored on the element it is about.** `Graph`, `Scope`, `Node` and `Param`
 each carry their own `Diagnostics`, and the graph itself takes what fits nothing narrower.
 `AllDiagnostics()` walks them and is what the encoders print; `Node.Faulty()` and
@@ -436,9 +441,10 @@ b.Report(di.Diagnostic{Severity: di.SeverityWarning, Site: di.AtService(def), Me
 ```
 
 The sites are `AtContainer()`, `AtScope(scope)`, `AtService(def)`, `AtFunction(def)`,
-`AtServiceArg(def, slot)` and `AtFunctionArg(def, slot)`. An error-severity diagnostic fails
-the build once the pass returns, so report it and return `nil`; a warning does not, and stays
-on the container the build produced.
+`AtServiceArg(def, slot)` and `AtFunctionArg(def, slot)`. A fault about several elements names
+the rest in `Related`, as sites of their own. The graph draws a candidate edge from the argument
+to each of them. An error-severity diagnostic fails the build once the pass returns, so report it
+and return `nil`; a warning does not, and stays on the container the build produced.
 
 No code is needed for the common case. Set `GODI_SNAPSHOT_ON_BUILD_ERR=true` and a failed
 `Build` writes its graph as JSON, printing the path and the command to run on stderr;

--- a/snapshot_faults_test.go
+++ b/snapshot_faults_test.go
@@ -231,6 +231,38 @@ func TestAFailingPassStillOwnsTheWiringItDid(t *testing.T) {
 	require.Equal(t, "interface binding", binding.OriginPass)
 }
 
+// An argument the interface binding pass gave up on has no wiring of its own to
+// draw: the build stops there, so nothing ever fills the slot and there is no
+// argument to trace. Without the implementations the pass reported, the picture
+// is a container of roots with no dependency in it at all, and the ambiguity is
+// the one thing the reader came to see.
+func TestAnArgumentThatCouldNotChooseShowsTheCandidates(t *testing.T) {
+	g := graphOfFailedBuild(t, godi.New().Services(
+		godi.Svc(NewFileReporter), godi.Svc(NewJSONReporter), godi.Svc(NewAudit),
+	))
+
+	param := paramOf(t, g, "v2_test.(*Audit)", 0)
+	require.True(t, param.Unwired(), "the build stopped before anything filled it")
+
+	edges := edgesOf(g, param)
+	require.Len(t, edges, 2, "both implementations are worth looking at")
+
+	targets := make([]graph.NodeID, 0, len(edges))
+	for _, e := range edges {
+		require.True(t, e.Candidate, "the container chose neither of them")
+		require.True(t, g.EdgeFaulty(e), "an argument that cannot choose resolves to neither")
+		targets = append(targets, e.To)
+	}
+	require.ElementsMatch(t, []graph.NodeID{
+		nodeOf(t, g, "v2_test.(*FileReporter)").ID,
+		nodeOf(t, g, "v2_test.(*JSONReporter)").ID,
+	}, targets)
+
+	require.Equal(t, 2, nodeOf(t, g, "v2_test.(*Audit)").OutDegree)
+	require.False(t, nodeOf(t, g, "v2_test.(*FileReporter)").Root,
+		"an implementation something could have taken is not the top of a tree")
+}
+
 // A definition that will not parse never becomes a node, so there is nothing
 // narrower than the container to say it on. Without this the snapshot leaves the
 // service out and says nothing at all.


### PR DESCRIPTION
Two services implementing one interface stopped the build before autowiring, so every slot was still empty and the failure snapshot showed a container of roots with no dependency in it. The ambiguity was the one thing the reader came for, and the picture said nothing about it.

A diagnostic can now name further elements in Related, and extraction draws one candidate edge per related definition on an argument that resolved to nothing. Nothing moves: no error string changes pass, no pass runs that did not run before, and the snapshot still fails at interface binding.

The ambiguity also lists each implementation with where it was registered. Two services of the same type are spelled the same, and the registration is all that tells them apart.